### PR TITLE
Moss

### DIFF
--- a/Client/Game.c
+++ b/Client/Game.c
@@ -1420,7 +1420,7 @@ void rr_game_connect_socket(struct rr_game *this)
 #else
     rr_websocket_init(&this->socket);
     this->socket.user_data = this;
-    rr_websocket_connect_to(&this->socket, "wss://1234-maxnest0x0-rysteria-et27742894k.ws-eu110.gitpod.io/");
+    rr_websocket_connect_to(&this->socket, "wss://1234-maxnest0x0-rysteria-et27742894k.ws-eu111.gitpod.io/");
     // rr_websocket_connect_to(&this->socket, "45.79.197.197", 1234, 0);
 #endif
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -76,6 +76,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                 setTimeout(() => window.location.reload(), 10000);
             }
         </script>
-        <script src="https://8080-maxnest0x0-rysteria-et27742894k.ws-eu110.gitpod.io/rrolf-client" onerror="rrolfError()"></script>
+        <script src="https://8080-maxnest0x0-rysteria-et27742894k.ws-eu111.gitpod.io/rrolf-client" onerror="rrolfError()"></script>
     </body>
 </html>


### PR DESCRIPTION
Moss petal, moss mob.

Under Client/Assets/RenderMobs.c on line 371 (I think) I commented the sprite-sheet place for moss mob, you can decide where it goes.

Moss is florr.io equivalent of rice

Moss mob despawns at mythic rarity same time as fern, since it is incredibly weak. 

Spawnrate for mob: 12.75 (Fern is 15)